### PR TITLE
Fix jest environment #3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,16 @@
 {
-  "presets": [
-    ["es2015", { "modules": false }],
-    "react"
-  ],
-  "plugins": [
-    "transform-class-properties",
-    "transform-object-rest-spread"
-  ]
+  "env": {
+    "development": {
+      "presets": [["es2015", { "modules": false }], "react"],
+      "plugins": ["transform-class-properties", "transform-object-rest-spread"]
+    },
+    "production": {
+      "presets": [["es2015", { "modules": false }], "react"],
+      "plugins": ["transform-class-properties", "transform-object-rest-spread"]
+    },
+    "test": {
+      "presets": ["es2015", "react"],
+      "plugins": ["transform-class-properties", "transform-object-rest-spread"]
+    }
+  }
 }

--- a/src/components/HelloWorld/__snapshots__/HelloWorld.test.jsx.snap
+++ b/src/components/HelloWorld/__snapshots__/HelloWorld.test.jsx.snap
@@ -1,4 +1,6 @@
-exports[`HelloWorld component should mount 1`] = `
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelloWorld works 1`] = `
 <div>
   <h2>
     Hello, 
@@ -7,6 +9,7 @@ exports[`HelloWorld component should mount 1`] = `
   </h2>
   <input
     onChange={[Function]}
-    value="Bob" />
+    value="Bob"
+  />
 </div>
 `;


### PR DESCRIPTION
Adding `modules: false` to `.babelrc` broke jest. This PR adds back module transformation for testing environment as well as updates the snapshot on the repo